### PR TITLE
Custom cancel and done buttons

### DIFF
--- a/Fastis.podspec
+++ b/Fastis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Fastis'
-  s.version          = '1.0.10'
+  s.version          = '1.0.11'
   s.summary          = "Simple date picker created using JTAppleCalendar library"
   s.description      = <<-DESC
   Fastis is a fully customizable UI component for picking dates and ranges created using JTAppleCalendar library.

--- a/Source/Views/Controller.swift
+++ b/Source/Views/Controller.swift
@@ -15,12 +15,24 @@ public class FastisController<Value: FastisValue>: UIViewController, JTACMonthVi
     // MARK: - Outlets
     
     private lazy var cancelBarButtonItem: UIBarButtonItem = {
+        if let customButton = self.appearance.customCancelButton {
+            customButton.target = self
+            customButton.action = #selector(self.cancel)
+            return customButton
+        }
+        
         let barButtonItem = UIBarButtonItem(title: self.appearance.cancelButtonTitle, style: .plain, target: self, action: #selector(self.cancel))
         barButtonItem.tintColor = self.appearance.barButtonItemsColor
         return barButtonItem
     }()
     
     private lazy var doneBarButtonItem: UIBarButtonItem = {
+        if let customButton = self.appearance.customDoneButton {
+            customButton.target = self
+            customButton.action = #selector(self.done)
+            return customButton
+        }
+        
         let barButtonItem = UIBarButtonItem(title: self.appearance.doneButtonTitle, style: .done, target: self, action: #selector(self.done))
         barButtonItem.tintColor = self.appearance.barButtonItemsColor
         barButtonItem.isEnabled = self.allowToChooseNilDate
@@ -526,5 +538,7 @@ extension FastisConfig {
         public var titleTextAttributes: [NSAttributedString.Key: Any] = [:]
         public var backgroundColor: UIColor = .white
         public var barButtonItemsColor: UIColor = .systemBlue
+        public var customCancelButton: UIBarButtonItem?
+        public var customDoneButton: UIBarButtonItem?
     }
 }


### PR DESCRIPTION
This PR extends `Controller` config with options to provide custom cancel and done buttons.
```
public var customCancelButton: UIBarButtonItem?
public var customDoneButton: UIBarButtonItem?
```