### PR TITLE
Day cell custom selection view corner radius and ranged background view inset.

### DIFF
--- a/Fastis.podspec
+++ b/Fastis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Fastis'
-  s.version          = '1.0.11'
+  s.version          = '1.0.12'
   s.summary          = "Simple date picker created using JTAppleCalendar library"
   s.description      = <<-DESC
   Fastis is a fully customizable UI component for picking dates and ranges created using JTAppleCalendar library.

--- a/Source/Views/DayCell.swift
+++ b/Source/Views/DayCell.swift
@@ -58,6 +58,7 @@ class DayCell: JTACDayCell {
     // MARK: - Variables
     
     private var config: FastisConfig.DayCell = FastisConfig.default.dayCell
+    private var rangedBackgroundViewTopBootomConstraints: [Constraint] = []
     
     // MARK: - Lifecycle
     
@@ -85,6 +86,10 @@ class DayCell: JTACDayCell {
         self.selectionBackgroundView.backgroundColor = config.selectedBackgroundColor
         self.dateLabel.font = config.dateLabelFont
         self.dateLabel.textColor = config.dateLabelColor
+        if let cornerRadius = config.customSelectionViewCornerRadius {
+             self.selectionBackgroundView.layer.cornerRadius = cornerRadius
+        }
+        rangedBackgroundViewTopBootomConstraints.map{ $0.update(inset: config.rangedBackgroundViewInset)}
     }
     
     public func configureSubviews() {
@@ -98,24 +103,25 @@ class DayCell: JTACDayCell {
     }
     
     public func configureConstraints() {
+        let inset = config.rangedBackgroundViewInset
         self.rangedBackgroundViewRoundedLeft.snp.makeConstraints { (maker) in
             maker.left.equalToSuperview()
-            maker.bottom.top.equalToSuperview().inset(3)
+            rangedBackgroundViewTopBootomConstraints.append(maker.bottom.top.equalToSuperview().inset(inset).constraint)
             maker.width.equalToSuperview().dividedBy(2)
         }
         self.rangedBackgroundViewSquaredLeft.snp.makeConstraints { (maker) in
             maker.left.equalToSuperview()
-            maker.bottom.top.equalToSuperview().inset(3)
+            rangedBackgroundViewTopBootomConstraints.append(maker.bottom.top.equalToSuperview().inset(inset).constraint)
             maker.width.equalToSuperview().dividedBy(2)
         }
         self.rangedBackgroundViewRoundedRight.snp.makeConstraints { (maker) in
             maker.right.equalToSuperview()
-            maker.bottom.top.equalToSuperview().inset(3)
+            rangedBackgroundViewTopBootomConstraints.append(maker.bottom.top.equalToSuperview().inset(inset).constraint)
             maker.width.equalToSuperview().dividedBy(2)
         }
         self.rangedBackgroundViewSquaredRight.snp.makeConstraints { (maker) in
             maker.right.equalToSuperview()
-            maker.bottom.top.equalToSuperview().inset(3)
+            rangedBackgroundViewTopBootomConstraints.append(maker.bottom.top.equalToSuperview().inset(inset).constraint)
             maker.width.equalToSuperview().dividedBy(2)
         }
         self.selectionBackgroundView.snp.makeConstraints { (maker) in
@@ -307,9 +313,12 @@ extension FastisConfig {
         public var rangeViewCornerRadius: CGFloat = 6
         public var onRangeBackgroundColor: UIColor = UIColor.systemBlue.withAlphaComponent(0.2)
         public var onRangeLabelColor: UIColor = .black
+        public var rangedBackgroundViewInset: CGFloat = 3
         
+        /**
+        This property allows to set custom radius for selection view. Circle is default.
+        */
+        public var customSelectionViewCornerRadius: CGFloat?
     }
-    
+
 }
-
-


### PR DESCRIPTION
This  PR extends `DayCell` configuration with two additional properties that allow to customise selection view corner radius and ranged background view inset.

```
public var rangedBackgroundViewInset: CGFloat = 3
public var customSelectionViewCornerRadius: CGFloat?
```
Example configurations:
<img width="359" alt="Screenshot 2020-09-25 at 12 52 11" src="https://user-images.githubusercontent.com/3175836/94259508-da0bb400-ff2e-11ea-961e-9904ae507577.png">
<img width="364" alt="Screenshot 2020-09-25 at 12 53 28" src="https://user-images.githubusercontent.com/3175836/94259513-dbd57780-ff2e-11ea-820b-98d13a9d845c.png">

@ilia3546 please take look 🙂
BTW. do you have idea how to remove this white vertical line between Thu - Fri?